### PR TITLE
fix: normalize script output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+package-lock.json

--- a/nodes/OpenAIScript.node.ts
+++ b/nodes/OpenAIScript.node.ts
@@ -76,6 +76,21 @@ export class OpenAIScript implements INodeType {
     } catch (error) {
       throw new NodeOperationError(this.getNode(), (error as Error).message);
     }
-    return this.prepareOutputData(result as any);
+
+    if (result === undefined) {
+      throw new NodeOperationError(this.getNode(), 'No data was returned from the script');
+    }
+
+    let returnData: INodeExecutionData[];
+    try {
+      returnData = this.helpers.returnJsonArray(result as any) as INodeExecutionData[];
+    } catch (error) {
+      throw new NodeOperationError(
+        this.getNode(),
+        'The script result could not be converted into items',
+      );
+    }
+
+    return this.prepareOutputData(returnData);
   }
 }


### PR DESCRIPTION
## Summary
- ensure OpenAI Script node converts user script results to n8n items
- add .gitignore for build artifacts
- surface script output failures with clear errors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689267272090832eab8509f5367c8e20