### PR TITLE
Add icon for OpenAI Script node

### DIFF
--- a/nodes/OpenAIScript.node.ts
+++ b/nodes/OpenAIScript.node.ts
@@ -9,6 +9,7 @@ export class OpenAIScript implements INodeType {
     group: ['transform'],
     version: 1,
     description: 'Execute arbitrary JavaScript with access to the OpenAI SDK',
+    icon: 'file:openai.svg',
     defaults: {
       name: 'OpenAI Script',
     },

--- a/nodes/openai.svg
+++ b/nodes/openai.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" rx="20" ry="20" fill="#10a37f"/>
+  <text x="50" y="62" font-size="40" text-anchor="middle" fill="#fff" font-family="Arial">&lt;ai&gt;</text>
+</svg>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && cp nodes/openai.svg dist/nodes/openai.svg",
     "prepare": "npm run build"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- show custom `<ai>` logo for OpenAI Script node in n8n editor
- copy icon into build output

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892632e5b1c832e96f000017b6c1c86