### PR TITLE
feat: add OpenAI API Endpoint credential

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+package-lock.json

--- a/credentials/OpenAIApiEndpoint.credentials.ts
+++ b/credentials/OpenAIApiEndpoint.credentials.ts
@@ -1,0 +1,30 @@
+import type { ICredentialType, INodeProperties } from 'n8n-workflow';
+
+export class OpenAIApiEndpoint implements ICredentialType {
+  name = 'openAiApiEndpoint';
+  displayName = 'OpenAI API Endpoint';
+  documentationUrl = 'https://platform.openai.com/docs/api-reference';
+
+  properties: INodeProperties[] = [
+    {
+      displayName: 'API Key',
+      name: 'apiKey',
+      type: 'string',
+      default: '',
+      required: true,
+      typeOptions: {
+        password: true,
+      },
+      description: 'Your OpenAI API key',
+    },
+    {
+      displayName: 'API Base URL',
+      name: 'baseUrl',
+      type: 'string',
+      default: '',
+      required: false,
+      description:
+        'Optional custom base URL for the OpenAI API. Leave blank to use the default https://api.openai.com/v1.',
+    },
+  ];
+}

--- a/nodes/OpenAIScript.node.ts
+++ b/nodes/OpenAIScript.node.ts
@@ -1,4 +1,4 @@
-import type { IExecuteFunctions, INodeExecutionData, INodeType, INodeTypeDescription } from 'n8n-workflow';
+import type { ICredentialDataDecryptedObject, IExecuteFunctions, INodeExecutionData, INodeType, INodeTypeDescription } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 import OpenAI from 'openai';
 
@@ -14,27 +14,13 @@ export class OpenAIScript implements INodeType {
     },
     inputs: ['main'],
     outputs: ['main'],
-    credentials: [],
-    properties: [
+    credentials: [
       {
-        displayName: 'API Key',
-        name: 'apiKey',
-        type: 'string',
-        default: '',
+        name: 'openAiApiEndpoint',
         required: true,
-        description: 'Your OpenAI API key',
-        typeOptions: {
-          password: true,
-        },
       },
-      {
-        displayName: 'API Base URL',
-        name: 'baseUrl',
-        type: 'string',
-        default: '',
-        description: 'Optional custom base URL for the OpenAI API. Leave blank to use the default https://api.openai.com/v1.',
-        required: false,
-      },
+    ],
+    properties: [
       {
         displayName: 'Script',
         name: 'script',
@@ -53,8 +39,9 @@ export class OpenAIScript implements INodeType {
 
   async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
     const items = this.getInputData();
-    const apiKey = this.getNodeParameter('apiKey', 0) as string;
-    const baseUrl = this.getNodeParameter('baseUrl', 0) as string;
+    const credentials = (await this.getCredentials('openAiApiEndpoint')) as ICredentialDataDecryptedObject;
+    const apiKey = credentials.apiKey as string;
+    const baseUrl = (credentials.baseUrl as string) || '';
     const script = this.getNodeParameter('script', 0) as string;
 
     const config: Record<string, any> = { apiKey };

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
   "n8n": {
     "nodes": [
       "dist/nodes/OpenAIScript.node.js"
+    ],
+    "credentials": [
+      "dist/credentials/OpenAIApiEndpoint.credentials.js"
     ]
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,6 @@
     "esModuleInterop": true,
     "skipLibCheck": true
   },
-  "include": ["nodes/**/*.ts"],
+  "include": ["nodes/**/*.ts", "credentials/**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- add OpenAI API Endpoint credential to store API key and optional base URL
- refactor OpenAIScript node to use the new credential
- register credential in build and package configuration

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68926722c4cc832ea055f19256a788c1