### PR TITLE
feat: enable JS editor for script input

### DIFF
--- a/nodes/OpenAIScript.node.ts
+++ b/nodes/OpenAIScript.node.ts
@@ -15,6 +15,7 @@ export class OpenAIScript implements INodeType {
     },
     inputs: ['main'],
     outputs: ['main'],
+    parameterPane: 'wide',
     credentials: [],
     properties: [
       {
@@ -41,13 +42,14 @@ export class OpenAIScript implements INodeType {
         name: 'script',
         type: 'string',
         typeOptions: {
-          rows: 8,
-          alwaysOpenEditWindow: true,
+          editor: 'codeNodeEditor',
+          editorLanguage: 'javaScript',
         },
         default: '',
         placeholder: 'return input;',
         description: 'Asynchronous JavaScript to execute. You can access `openai`, `input`, and `require`.',
         required: true,
+        noDataExpression: true,
       },
     ],
   };


### PR DESCRIPTION
## Summary
- show script input in a JavaScript code editor
- allow expanding the script editor like the standard Code node

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689270625ab4832ea276337630d14c66