### PR TITLE
Use compact code editor for OpenAI Script node

### DIFF
--- a/nodes/OpenAIScript.node.ts
+++ b/nodes/OpenAIScript.node.ts
@@ -29,8 +29,10 @@ export class OpenAIScript implements INodeType {
         name: 'script',
         type: 'string',
         typeOptions: {
-          editor: 'codeNodeEditor',
-          editorLanguage: 'javaScript',
+          editor: 'jsEditor',
+          rows: 10,
+          alwaysOpenEditWindow: false,
+          codeAutocomplete: 'function',
         },
         default: '',
         placeholder: 'return input;',


### PR DESCRIPTION
## Summary
- avoid auto-expanding script editor by switching to jsEditor
- configure editor options for inline editing with optional expansion

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68927a918898832e88e7017819783231