### PR TITLE
feat: categorize OpenAI script under AI

### DIFF
--- a/nodes/OpenAIScript.node.json
+++ b/nodes/OpenAIScript.node.json
@@ -1,0 +1,10 @@
+{
+  "node": "n8n-nodes-openai-script.openAIScript",
+  "nodeVersion": "1.0",
+  "codexVersion": "1.0",
+  "details": "Execute arbitrary JavaScript with access to the OpenAI SDK",
+  "categories": ["Utility"],
+  "subcategories": {
+    "Utility": ["AI"]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc && cp nodes/openai.svg dist/nodes/openai.svg",
+    "build": "tsc && cp nodes/openai.svg dist/nodes/openai.svg && cp nodes/*.node.json dist/nodes/",
     "prepare": "npm run build"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add codex file to classify OpenAI Script node under Utility → AI
- copy node codex file during build

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68927f2877b0832e9faed9c64eea86d8