### PR TITLE
feat: add credential icon

### DIFF
--- a/credentials/OpenAIApiEndpoint.credentials.ts
+++ b/credentials/OpenAIApiEndpoint.credentials.ts
@@ -1,9 +1,10 @@
-import type { ICredentialType, INodeProperties } from 'n8n-workflow';
+import type { ICredentialType, INodeProperties, Icon } from 'n8n-workflow';
 
 export class OpenAIApiEndpoint implements ICredentialType {
   name = 'openAiApiEndpoint';
   displayName = 'OpenAI API Endpoint';
   documentationUrl = 'https://platform.openai.com/docs/api-reference';
+  icon: Icon = 'file:openai.svg';
 
   properties: INodeProperties[] = [
     {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc && cp nodes/openai.svg dist/nodes/openai.svg",
+    "build": "tsc && cp nodes/openai.svg dist/nodes/openai.svg && cp nodes/openai.svg dist/credentials/openai.svg",
     "prepare": "npm run build"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- include OpenAI icon in credential definition
- copy OpenAI icon from nodes directory for both nodes and credentials during build

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68927ec20324832e8e8ea2fd60ebcd46