### PR TITLE
Expose OpenAI client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # n8n‑nodes‑openai‑script
 
-An external node for [n8n](https://n8n.io/) that lets you run arbitrary asynchronous JavaScript with access to the [OpenAI TypeScript SDK](https://www.npmjs.com/package/openai). The node executes your script inside a `new Function` context and exposes a pre‑configured `openai` client, the incoming items, and the Node.js `require` function. Whatever value you `return` from your script becomes the output of the node.
+An external node for [n8n](https://n8n.io/) that lets you run arbitrary asynchronous JavaScript with access to the [OpenAI TypeScript SDK](https://www.npmjs.com/package/openai). The node executes your script inside a `new Function` context and exposes a pre‑configured OpenAI client (available as `openai` or `client`), the incoming items, and the Node.js `require` function. Whatever value you `return` from your script becomes the output of the node.
 
 ## Features
 
 * **Execute custom code** – Write any asynchronous JavaScript and use `await` without boilerplate.
-* **OpenAI SDK** – A fully initialised `openai` client is injected into your script, allowing you to call any OpenAI API supported by version 5.11.0.
+* **OpenAI SDK** – A fully initialised OpenAI client is injected into your script (accessible via `openai` or `client`), allowing you to call any OpenAI API supported by version 5.11.0.
 * **Access input items** – The `input` variable contains the array of items returned by `this.getInputData()`.
 * **Use `require`** – Import additional Node.js packages available in your n8n instance using the familiar `require()` syntax. The module bundles popular helpers like `langchain` out of the box.
 * **Flexible execution** – Choose between running your script once for all items or once per incoming item.
@@ -93,9 +93,9 @@ docker run -it --rm -p 5678:5678 n8n-custom
 
 After installation, search for **OpenAI Script** in the n8n editor and drag the node into your workflow. The node exposes two parameters:
 
-* **API Key** – Your OpenAI API key. This key is used to create the `openai` client. It is not persisted anywhere by the node.
+* **API Key** – Your OpenAI API key. This key is used to create the client. It is not persisted anywhere by the node.
 * **Script** – A text area where you can write asynchronous JavaScript. You have access to the following variables:
-  * `openai` – An instance of the OpenAI SDK initialised with your API key.
+  * `openai`/`client` – An instance of the OpenAI SDK initialised with your API key.
   * `input` – The input items array returned by `this.getInputData()`.
   * `item` – In per-item mode, the current item being processed.
   * `require` – Node.js `require()` function to import additional packages installed in the environment.

--- a/nodes/OpenAIScript.node.ts
+++ b/nodes/OpenAIScript.node.ts
@@ -79,7 +79,8 @@ export class OpenAIScript implements INodeType {
     if (baseUrl) {
       config.baseURL = baseUrl;
     }
-    const openai = new OpenAI(config);
+    const client = new OpenAI(config);
+    const openai = client;
 
     const requireFn = createRequire(__filename);
 
@@ -88,6 +89,7 @@ export class OpenAIScript implements INodeType {
       return new Proxy(
         {
           openai,
+          client,
           input: inputData,
           item: inputData,
           require: requireFn,

--- a/test/test-script.js
+++ b/test/test-script.js
@@ -16,6 +16,7 @@ const { OpenAIScript } = require('../dist/nodes/OpenAIScript.node.js');
           "const os = require('os');" +
           "\nconsole.log('platform', os.platform());" +
           "\nconsole.log('openai chat defined', typeof openai.chat);" +
+          "\nconsole.log('client chat defined', typeof client.chat);" +
           "\nconsole.log('fetch defined', typeof fetch);" +
           "\nconsole.log('json stringify works', JSON.stringify({ test: 1 }));" +
           "\nreturn { ok: true };"


### PR DESCRIPTION
## Summary
- expose instantiated OpenAI client as `client` in workflow context
- document availability of `client` alias alongside `openai`
- update test to confirm `client` is provided

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68930b40860c832e8363c11ca13a2fce