### PR TITLE
Ensure full input array available in per-item mode

### DIFF
--- a/nodes/OpenAIScript.node.ts
+++ b/nodes/OpenAIScript.node.ts
@@ -60,7 +60,7 @@ export class OpenAIScript implements INodeType {
         },
         default: '',
         description:
-          'Asynchronous JavaScript to execute. You can access `openai`, `input`, `require`, `fetch`, `JSON`, and workflow helpers like `$json` and `$input`.',
+          'Asynchronous JavaScript to execute. You can access `openai`, `input`, `item`, `require`, `fetch`, `JSON`, and workflow helpers like `$json` and `$input`.',
         noDataExpression: true,
         required: true,
       },
@@ -83,13 +83,13 @@ export class OpenAIScript implements INodeType {
 
     const requireFn = createRequire(__filename);
 
-    const createWorkflowProxy = (index: number, inputData: any) => {
+    const createWorkflowProxy = (index: number) => {
       const dataProxy = this.getWorkflowDataProxy(index);
       return new Proxy(
         {
           openai,
-          input: inputData,
-          item: inputData,
+          input: items,
+          item: items[index],
           require: requireFn,
           console,
           fetch: (globalThis as any).fetch,
@@ -122,7 +122,7 @@ export class OpenAIScript implements INodeType {
     if (mode === 'runOnceForAllItems') {
       let result: unknown;
       try {
-        result = await asyncFunction(createWorkflowProxy(0, items));
+        result = await asyncFunction(createWorkflowProxy(0));
       } catch (error) {
         throw new NodeOperationError(this.getNode(), (error as Error).message);
       }
@@ -145,7 +145,7 @@ export class OpenAIScript implements INodeType {
       for (let i = 0; i < items.length; i++) {
         let result: unknown;
         try {
-          result = await asyncFunction(createWorkflowProxy(i, items[i]));
+          result = await asyncFunction(createWorkflowProxy(i));
         } catch (error) {
           throw new NodeOperationError(this.getNode(), (error as Error).message, { itemIndex: i });
         }

--- a/test/test-script.js
+++ b/test/test-script.js
@@ -3,10 +3,29 @@ const { OpenAIScript } = require('../dist/nodes/OpenAIScript.node.js');
 (async () => {
   const node = new OpenAIScript();
 
-  const context = {
+  const baseContext = {
     async getCredentials() {
       return { apiKey: 'test', baseUrl: '' };
     },
+    getWorkflowDataProxy() {
+      return {};
+    },
+    getNode() {
+      return {};
+    },
+    helpers: {
+      returnJsonArray(data) {
+        return Array.isArray(data) ? data : [data];
+      },
+    },
+    prepareOutputData(data) {
+      return [data];
+    },
+  };
+
+  // Run once for all items
+  let context = {
+    ...baseContext,
     getInputData() {
       return [];
     },
@@ -26,22 +45,29 @@ const { OpenAIScript } = require('../dist/nodes/OpenAIScript.node.js');
       }
       return '';
     },
-    getWorkflowDataProxy() {
-      return {};
+  };
+
+  let result = await node.execute.call(context);
+  console.log('result1', JSON.stringify(result));
+
+  // Run once for each item and expose full input array
+  const items = [{ json: { index: 0 } }, { json: { index: 1 } }];
+  context = {
+    ...baseContext,
+    getInputData() {
+      return items;
     },
-    getNode() {
-      return {};
-    },
-    helpers: {
-      returnJsonArray(data) {
-        return Array.isArray(data) ? data : [data];
-      },
-    },
-    prepareOutputData(data) {
-      return [data];
+    getNodeParameter(name) {
+      if (name === 'script') {
+        return "return { len: input.length, idx: item.json.index };";
+      }
+      if (name === 'mode') {
+        return 'runOnceForEachItem';
+      }
+      return '';
     },
   };
 
-  const result = await node.execute.call(context);
-  console.log('result', JSON.stringify(result));
+  result = await node.execute.call(context);
+  console.log('result2', JSON.stringify(result));
 })();


### PR DESCRIPTION
## Summary
- always expose entire input array alongside current item inside user scripts
- document `item` availability and keep input array in tests
- expand test to cover per-item execution

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68930fb5112c832e9bdb29f168219e27