### PR TITLE
Configure TypeScript for Node typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "devDependencies": {
     "n8n-core": "^1.97.0",
     "n8n-workflow": "^1.97.0",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "@types/node": "^20.14.10"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,9 @@
     "rootDir": ".",
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "moduleResolution": "node",
+    "types": ["node"]
   },
   "include": ["nodes/**/*.ts", "credentials/**/*.ts"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary
- add `@types/node` to the development dependencies to provide Node.js typings
- configure the TypeScript compiler to resolve modules using Node semantics and include Node types

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d26aeb37f4832ead8f07ce1fc2b709