### PR TITLE
Update inline editor patch to treat unsafe code node as editable

### DIFF
--- a/scripts/enable-inline-editor.js
+++ b/scripts/enable-inline-editor.js
@@ -29,7 +29,59 @@ if (process.env.N8N_EDITOR_UI_PATH) {
   searchRoots.add(path.resolve(process.env.N8N_EDITOR_UI_PATH));
 }
 
-const candidateExtensions = ['.ts', '.js', '.mjs', '.cjs'];
+const candidateExtensions = ['.ts', '.js', '.mjs', '.cjs', '.vue'];
+
+const CODE_NODE_VAR_REGEX = /([A-Za-z_$][\w$]*)\s*=\s*['"]n8n-nodes-base\.code['"]/g;
+const CODE_NODE_TYPE_IDENTIFIER = 'CODE_NODE_TYPE';
+
+function patchCodeNodeEquality(content) {
+  let updated = content;
+  let changed = false;
+
+  const ensureEqualityIncludesUnsafe = (identifier) => {
+    const identifierPattern = '(?:[\\w$]+(?:\\.[\\w$]+)*)\\.type';
+    const equalityRegex = new RegExp(
+      `(${identifierPattern})\\s*===\\s*${identifier}(?!\\s*\\|\\|\\s*\\1\\.type\\s*===\\s*['\"]${NODE_TYPE}['\"])`,
+      'g',
+    );
+
+    updated = updated.replace(equalityRegex, (match, left) => {
+      changed = true;
+      return `${match}||${left}.type==='${NODE_TYPE}'`;
+    });
+  };
+
+  ensureEqualityIncludesUnsafe(CODE_NODE_TYPE_IDENTIFIER);
+
+  const varNames = new Set();
+  let match;
+  while ((match = CODE_NODE_VAR_REGEX.exec(updated)) !== null) {
+    if (match[1] !== CODE_NODE_TYPE_IDENTIFIER) {
+      varNames.add(match[1]);
+    }
+  }
+
+  for (const varName of varNames) {
+    ensureEqualityIncludesUnsafe(varName);
+  }
+
+  const explicitCheck = `node.type === ${CODE_NODE_TYPE_IDENTIFIER}`;
+  const explicitCheckCompact = `node.type===${CODE_NODE_TYPE_IDENTIFIER}`;
+  const replacement = `node.type === ${CODE_NODE_TYPE_IDENTIFIER} || node.type === '${NODE_TYPE}'`;
+  const replacementCompact = `node.type===${CODE_NODE_TYPE_IDENTIFIER}||node.type==='${NODE_TYPE}'`;
+
+  if (updated.includes(explicitCheck) && !updated.includes(replacement)) {
+    updated = updated.replace(new RegExp(explicitCheck, 'g'), replacement);
+    changed = true;
+  }
+
+  if (updated.includes(explicitCheckCompact) && !updated.includes(replacementCompact)) {
+    updated = updated.replace(new RegExp(explicitCheckCompact, 'g'), replacementCompact);
+    changed = true;
+  }
+
+  return { updated, changed };
+}
 
 function patchFile(filePath) {
   if (visited.has(filePath)) return;
@@ -42,73 +94,79 @@ function patchFile(filePath) {
     return;
   }
 
-  if (!content.includes('NODES_USING_CODE_NODE_EDITOR')) return;
-  if (content.includes(NODE_TYPE)) return;
+  let updated = content;
+  let changed = false;
 
-  const markerIndex = content.indexOf('NODES_USING_CODE_NODE_EDITOR');
-  if (markerIndex === -1) return;
+  if (content.includes('NODES_USING_CODE_NODE_EDITOR') && !content.includes(NODE_TYPE)) {
+    const markerIndex = content.indexOf('NODES_USING_CODE_NODE_EDITOR');
+    if (markerIndex !== -1) {
+      const openBracketIndex = content.indexOf('[', markerIndex);
+      if (openBracketIndex !== -1) {
+        const closeSequence = '];';
+        const closeIndex = content.indexOf(closeSequence, openBracketIndex);
+        if (closeIndex !== -1) {
+          const arrayContent = content.slice(openBracketIndex + 1, closeIndex);
+          if (!arrayContent.includes(NODE_TYPE)) {
+            let newArrayContent;
 
-  const openBracketIndex = content.indexOf('[', markerIndex);
-  if (openBracketIndex === -1) return;
+            if (!arrayContent.includes('\n')) {
+              const trimmed = arrayContent.trim();
+              if (trimmed.length === 0) {
+                newArrayContent = `'${NODE_TYPE}'`;
+              } else {
+                const normalized = trimmed.endsWith(',') ? trimmed.slice(0, -1).trimEnd() : trimmed;
+                newArrayContent = `${normalized}, '${NODE_TYPE}'`;
+              }
 
-  const closeSequence = '];';
-  const closeIndex = content.indexOf(closeSequence, openBracketIndex);
-  if (closeIndex === -1) return;
+              const before = content.slice(0, openBracketIndex + 1);
+              const after = content.slice(closeIndex);
+              const needsPadding = newArrayContent.length > 0 ? ' ' : '';
+              updated = `${before}${needsPadding}${newArrayContent}${needsPadding}${after}`;
+            } else {
+              const lines = arrayContent.split('\n');
+              let lastContentIndex = -1;
+              for (let i = lines.length - 1; i >= 0; i -= 1) {
+                if (lines[i].trim().length > 0) {
+                  lastContentIndex = i;
+                  break;
+                }
+              }
 
-  const arrayContent = content.slice(openBracketIndex + 1, closeIndex);
-  if (arrayContent.includes(NODE_TYPE)) return;
+              if (lastContentIndex === -1) {
+                const indent = '        ';
+                const insertionLine = `${indent}'${NODE_TYPE}',`;
+                if (lines.length === 1) {
+                  lines[0] = insertionLine;
+                } else {
+                  lines.splice(lines.length - 1, 0, insertionLine);
+                }
+              } else {
+                if (!lines[lastContentIndex].trim().endsWith(',')) {
+                  lines[lastContentIndex] = `${lines[lastContentIndex].trimEnd()},`;
+                }
+                const indentMatch = lines[lastContentIndex].match(/^\s*/);
+                const indent = indentMatch ? indentMatch[0] : '        ';
+                lines.splice(lastContentIndex + 1, 0, `${indent}'${NODE_TYPE}',`);
+              }
 
-  let newArrayContent;
+              updated = `${content.slice(0, openBracketIndex + 1)}${lines.join('\n')}${content.slice(closeIndex)}`;
+            }
 
-  if (!arrayContent.includes('\n')) {
-    const trimmed = arrayContent.trim();
-    if (trimmed.length === 0) {
-      newArrayContent = `'${NODE_TYPE}'`;
-    } else {
-      const normalized = trimmed.endsWith(',') ? trimmed.slice(0, -1).trimEnd() : trimmed;
-      newArrayContent = `${normalized}, '${NODE_TYPE}'`;
+            changed = true;
+          }
+        }
+      }
     }
+  }
 
-    const before = content.slice(0, openBracketIndex + 1);
-    const after = content.slice(closeIndex);
-    const needsPadding = newArrayContent.length > 0 ? ' ' : '';
-    const updatedContent = `${before}${needsPadding}${newArrayContent}${needsPadding}${after}`;
+  const equalityResult = patchCodeNodeEquality(updated);
+  updated = equalityResult.updated;
+  changed = changed || equalityResult.changed;
 
-    fs.writeFileSync(filePath, updatedContent, 'utf8');
+  if (changed) {
+    fs.writeFileSync(filePath, updated, 'utf8');
     patchedFiles.push(filePath);
-    return;
   }
-
-  const lines = arrayContent.split('\n');
-  let lastContentIndex = -1;
-  for (let i = lines.length - 1; i >= 0; i -= 1) {
-    if (lines[i].trim().length > 0) {
-      lastContentIndex = i;
-      break;
-    }
-  }
-
-  if (lastContentIndex === -1) {
-    const indent = '        ';
-    const insertionLine = `${indent}'${NODE_TYPE}',`;
-    if (lines.length === 1) {
-      lines[0] = insertionLine;
-    } else {
-      lines.splice(lines.length - 1, 0, insertionLine);
-    }
-  } else {
-    if (!lines[lastContentIndex].trim().endsWith(',')) {
-      lines[lastContentIndex] = `${lines[lastContentIndex].trimEnd()},`;
-    }
-    const indentMatch = lines[lastContentIndex].match(/^\s*/);
-    const indent = indentMatch ? indentMatch[0] : '        ';
-    lines.splice(lastContentIndex + 1, 0, `${indent}'${NODE_TYPE}',`);
-  }
-
-  const newContent = `${content.slice(0, openBracketIndex + 1)}${lines.join('\n')}${content.slice(closeIndex)}`;
-
-  fs.writeFileSync(filePath, newContent, 'utf8');
-  patchedFiles.push(filePath);
 }
 
 function walkDirectory(dir, depth = 0) {


### PR DESCRIPTION
## Summary
- extend the UI patcher to scan Vue sources and to add the unsafe code node to any allowlists it finds
- detect code-node equality checks (both in source and minified bundles) and append the unsafe node type so inline editing and drag-and-drop work again
- keep the original array mutation logic while collapsing the write operations into a single path per file

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3d9be47b4832ea2b4891cdb1620e1