### PR TITLE
Add Unsafe Code API credentials support

### DIFF
--- a/credentials/UnsafeCodeApi.credentials.ts
+++ b/credentials/UnsafeCodeApi.credentials.ts
@@ -1,0 +1,30 @@
+import type { ICredentialType, INodeProperties } from 'n8n-workflow';
+
+export class UnsafeCodeApi implements ICredentialType {
+  name = 'unsafeCodeApi';
+
+  displayName = 'Unsafe Code API';
+
+  properties: INodeProperties[] = [
+    {
+      displayName: 'Base URL',
+      name: 'url',
+      type: 'string',
+      default: '',
+      placeholder: 'https://example.com',
+      description: 'Base URL of the API',
+      required: true,
+    },
+    {
+      displayName: 'Bearer Token',
+      name: 'token',
+      type: 'string',
+      typeOptions: {
+        password: true,
+      },
+      default: '',
+      description: 'Token to use for bearer authentication',
+      required: true,
+    },
+  ];
+}

--- a/nodes/UnsafeCode.node.ts
+++ b/nodes/UnsafeCode.node.ts
@@ -141,6 +141,12 @@ export class UnsafeCode implements INodeType {
     inputs: ['main'],
     outputs: ['main'],
     parameterPane: 'wide',
+    credentials: [
+      {
+        name: 'unsafeCodeApi',
+        required: false,
+      },
+    ],
     properties: [
       {
         displayName: 'Mode',
@@ -208,6 +214,20 @@ export class UnsafeCode implements INodeType {
 
     const runUserCode = async (index: number, contextData: IDataObject): Promise<unknown> => {
       const script = this.getNodeParameter('jsCode', index) as string;
+      const credentialData = (await this.getCredentials('unsafeCodeApi')) as IDataObject | null;
+      const exposedCredential =
+        credentialData !== null
+          ? Object.freeze({
+              url:
+                typeof credentialData.url === 'string'
+                  ? credentialData.url
+                  : String(credentialData.url ?? ''),
+              token:
+                typeof credentialData.token === 'string'
+                  ? credentialData.token
+                  : String(credentialData.token ?? ''),
+            })
+          : undefined;
       const dataProxy = this.getWorkflowDataProxy(index);
 
       const helpers = {
@@ -241,6 +261,13 @@ export class UnsafeCode implements INodeType {
         clearTimeout,
         clearInterval,
       };
+
+      Object.defineProperty(context, 'UNSAFE_CODE_CREDENTIALS', {
+        value: exposedCredential,
+        writable: false,
+        configurable: false,
+        enumerable: true,
+      });
 
       const contextProxy = new Proxy(context, {
         has() {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
   "n8n": {
     "nodes": [
       "dist/nodes/UnsafeCode.node.js"
+    ],
+    "credentials": [
+      "dist/credentials/UnsafeCodeApi.credentials.js"
     ]
   }
 }

--- a/test/test-script.js
+++ b/test/test-script.js
@@ -37,6 +37,9 @@ const { UnsafeCode } = require('../dist/nodes/UnsafeCode.node.js');
     getWorkflowStaticData() {
       return {};
     },
+    async getCredentials() {
+      return null;
+    },
     getMode() {
       return 'integrated';
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,6 @@
     "moduleResolution": "node",
     "types": ["node"]
   },
-  "include": ["nodes/**/*.ts"],
+  "include": ["nodes/**/*.ts", "credentials/**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- add an Unsafe Code API credential type with base URL and bearer token fields
- register the credential on the node and expose it to user scripts via an immutable context value
- include credentials in the TypeScript build and update the test harness to stub credential access

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d42e5566e4832e9700156b76980168