### PR TITLE
Fix error routing for Unsafe Code runtime failures

### DIFF
--- a/nodes/UnsafeCode.node.ts
+++ b/nodes/UnsafeCode.node.ts
@@ -303,7 +303,7 @@ export class UnsafeCode implements INodeType {
       try {
         result = await asyncFunction(contextProxy);
       } catch (error) {
-        throw new NodeOperationError(this.getNode(), (error as Error).message, {
+        throw new NodeOperationError(this.getNode(), error as Error, {
           itemIndex: mode === 'runOnceForEachItem' ? index : undefined,
         });
       }


### PR DESCRIPTION
## Summary
- ensure runtime exceptions thrown inside the Unsafe Code node are rethrown with their original error objects so n8n can route them to the error output

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_6901d50b6f408321ab36301b7da5fe6e