### PR TITLE
Fix continue-on-fail detection in Unsafe Code node

### DIFF
--- a/nodes/UnsafeCode.node.ts
+++ b/nodes/UnsafeCode.node.ts
@@ -139,7 +139,14 @@ export class UnsafeCode implements INodeType {
       name: 'Unsafe Code',
     },
     inputs: ['main'],
-    outputs: ['main'],
+    outputs: [
+      'main',
+      {
+        type: 'main',
+        category: 'error',
+      },
+    ],
+    outputNames: ['Main', 'Error'],
     parameterPane: 'wide',
     credentials: [
       {
@@ -184,10 +191,16 @@ export class UnsafeCode implements INodeType {
   };
 
   async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+    const node = this.getNode();
     const items = this.getInputData();
     const mode = this.getNodeParameter('mode', 0) as 'runOnceForAllItems' | 'runOnceForEachItem';
     const workflowMode = this.getMode();
     const requireFn = createRequire(__filename);
+
+    const continueOnFail = this.continueOnFail();
+    const onErrorBehaviour = node.onError ?? (continueOnFail ? 'continueRegularOutput' : 'stopWorkflow');
+    const shouldContinueOnFail = onErrorBehaviour !== 'stopWorkflow';
+    const useErrorOutput = onErrorBehaviour === 'continueErrorOutput';
 
     const consoleBinding = (() => {
       if (workflowMode !== 'manual') {
@@ -303,7 +316,7 @@ export class UnsafeCode implements INodeType {
       try {
         result = await asyncFunction(contextProxy);
       } catch (error) {
-        throw new NodeOperationError(this.getNode(), (error as Error).message, {
+        throw new NodeOperationError(node, error as Error, {
           itemIndex: mode === 'runOnceForEachItem' ? index : undefined,
         });
       }
@@ -321,32 +334,100 @@ export class UnsafeCode implements INodeType {
       return result;
     };
 
+    const mainOutput: INodeExecutionData[] = [];
+    const errorOutput: INodeExecutionData[] = [];
+
+    const addToMainOutput = (result: unknown, itemIndex?: number) => {
+      const normalized = normalizeResult(node, result, itemIndex);
+      normalized.forEach((item) => {
+        if (mode === 'runOnceForEachItem' && itemIndex !== undefined && !item.pairedItem) {
+          item.pairedItem = { item: itemIndex };
+        }
+        if (item.json && isObject(item.json)) {
+          item.json = standardizeOutput(item.json);
+        }
+        mainOutput.push(item);
+      });
+    };
+
+    const wrapNodeError = (error: unknown, itemIndex?: number): NodeOperationError => {
+      if (error instanceof NodeOperationError) {
+        if (mode === 'runOnceForEachItem' && itemIndex !== undefined && error.context.itemIndex === undefined) {
+          error.context.itemIndex = itemIndex;
+        }
+        return error;
+      }
+
+      if (error instanceof Error || typeof error === 'string') {
+        return new NodeOperationError(node, error, {
+          itemIndex: mode === 'runOnceForEachItem' ? itemIndex : undefined,
+        });
+      }
+
+      return new NodeOperationError(node, new Error('Unknown error'), {
+        itemIndex: mode === 'runOnceForEachItem' ? itemIndex : undefined,
+      });
+    };
+
+    const pushErrorOutput = (error: unknown, itemIndex?: number) => {
+      const nodeError = wrapNodeError(error, itemIndex);
+
+      if (!shouldContinueOnFail) {
+        throw nodeError;
+      }
+
+      const baseErrorJson = {
+        message: nodeError.message,
+        name: nodeError.name,
+      } as IDataObject;
+
+      if (nodeError.stack) {
+        baseErrorJson.stack = nodeError.stack;
+      }
+
+      const pairedItem =
+        mode === 'runOnceForEachItem'
+          ? itemIndex !== undefined
+            ? { item: itemIndex }
+            : undefined
+          : items.length > 0
+            ? items.map((_, inputIndex) => ({ item: inputIndex }))
+            : undefined;
+
+      const errorItem: INodeExecutionData = {
+        json: { error: baseErrorJson },
+        ...(pairedItem ? { pairedItem } : {}),
+      };
+
+      if (useErrorOutput) {
+        errorOutput.push(errorItem);
+        return;
+      }
+
+      mainOutput.push(errorItem);
+    };
+
     if (mode === 'runOnceForAllItems') {
-      const result = await runUserCode(0, { items });
-      const normalized = normalizeResult(this.getNode(), result);
-      normalized.forEach((item) => {
-        if (item.json && isObject(item.json)) {
-          item.json = standardizeOutput(item.json);
+      try {
+        const result = await runUserCode(0, { items });
+        addToMainOutput(result);
+      } catch (error) {
+        pushErrorOutput(error);
+      }
+    } else {
+      for (let index = 0; index < items.length; index++) {
+        try {
+          const result = await runUserCode(index, { item: items[index] });
+          addToMainOutput(result, index);
+        } catch (error) {
+          pushErrorOutput(error, index);
         }
-      });
-      return this.prepareOutputData(normalized);
+      }
     }
 
-    const returnData: INodeExecutionData[] = [];
-    for (let index = 0; index < items.length; index++) {
-      const result = await runUserCode(index, { item: items[index] });
-      const normalized = normalizeResult(this.getNode(), result, index);
-      normalized.forEach((item) => {
-        if (!item.pairedItem) {
-          item.pairedItem = { item: index };
-        }
-        if (item.json && isObject(item.json)) {
-          item.json = standardizeOutput(item.json);
-        }
-        returnData.push(item);
-      });
-    }
+    const [preparedMain] = await this.prepareOutputData(mainOutput);
+    const [preparedError] = await this.prepareOutputData(errorOutput);
 
-    return this.prepareOutputData(returnData);
+    return [preparedMain, preparedError];
   }
 }

--- a/test/test-script.js
+++ b/test/test-script.js
@@ -3,14 +3,33 @@ const { UnsafeCode } = require('../dist/nodes/UnsafeCode.node.js');
 (async () => {
   const node = new UnsafeCode();
 
-  const items = [
-    { json: { value: 1 } },
-    { json: { value: 2 } },
-  ];
+  const baseContext = {
+    getWorkflowDataProxy() {
+      return {};
+    },
+    getWorkflowStaticData() {
+      return {};
+    },
+    continueOnFail() {
+      return false;
+    },
+    async getCredentials() {
+      return null;
+    },
+    helpers: {},
+    prepareOutputData(data) {
+      return [data];
+    },
+    sendMessageToUI() {},
+  };
 
-  const context = {
+  const successContext = {
+    ...baseContext,
     getInputData() {
-      return items;
+      return [
+        { json: { value: 1 } },
+        { json: { value: 2 } },
+      ];
     },
     getNodeParameter(name) {
       if (name === 'mode') {
@@ -31,27 +50,61 @@ const { UnsafeCode } = require('../dist/nodes/UnsafeCode.node.js');
       }
       return '';
     },
-    getWorkflowDataProxy() {
-      return {};
-    },
-    getWorkflowStaticData() {
-      return {};
-    },
-    async getCredentials() {
-      return null;
-    },
     getMode() {
       return 'integrated';
     },
     getNode() {
       return { name: 'Unsafe Code' };
     },
-    helpers: {},
-    prepareOutputData(data) {
-      return [data];
+  };
+
+  const result = await node.execute.call(successContext);
+  console.log('success', JSON.stringify(result));
+
+  const errorScript = "nonExistentFunction();\nreturn [{ json: { ok: true } }];";
+
+  const errorBase = {
+    ...baseContext,
+    getInputData() {
+      return [{ json: { value: 1 } }];
+    },
+    getNodeParameter(name) {
+      if (name === 'mode') {
+        return 'runOnceForAllItems';
+      }
+      if (name === 'jsCode') {
+        return errorScript;
+      }
+      return '';
+    },
+    getMode() {
+      return 'manual';
     },
   };
 
-  const result = await node.execute.call(context);
-  console.log('result', JSON.stringify(result));
+  const errorOutputContext = {
+    ...errorBase,
+    getNode() {
+      return { name: 'Unsafe Code', onError: 'continueErrorOutput' };
+    },
+    continueOnFail() {
+      return true;
+    },
+  };
+
+  const mainOutputContext = {
+    ...errorBase,
+    getNode() {
+      return { name: 'Unsafe Code', onError: 'continueRegularOutput' };
+    },
+    continueOnFail() {
+      return true;
+    },
+  };
+
+  const errorOutputResult = await node.execute.call(errorOutputContext);
+  console.log('errorOutput', JSON.stringify(errorOutputResult));
+
+  const mainOutputResult = await node.execute.call(mainOutputContext);
+  console.log('mainOutput', JSON.stringify(mainOutputResult));
 })();


### PR DESCRIPTION
## Summary
- align the Unsafe Code node's error routing with the runtime continueOnFail flag so errors reach the configured output
- extend the test harness to provide a default continueOnFail implementation for success scenarios

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_6901d50b6f408321ab36301b7da5fe6e